### PR TITLE
Adding subTypes parameter to async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,22 @@ export const types = createTypes('my-app/module/',
 
 /*
   types = {
-    SORT: 'my-app/module/SORT',
-    ADD: 'my-app/module/ADD',
-    LOAD_SUCCESS: 'my-app/module/LOAD_SUCCESS',
-    LOAD_FAIL: 'my-app/module/LOAD_FAIL',
-    SAVE_SUCCESS: 'my-app/module/SAVE_SUCCESS',
-    SAVE_FAIL: 'my-app/module/SAVE_FAIL',
-    UPDATE_SUCCESS: 'my-app/module/UPDATE_SUCCESS',
-    UPDATE_FAIL: 'my-app/module/UPDATE_FAIL',
-    REMOVE_SUCCESS: 'my-app/module/REMOVE_REQUEST',
-    REMOVE_FAIL: 'my-app/module/REMOVE_COMPLETE'
+    SORT: "my-app/module/SORT"
+    ADD: "my-app/module/ADD"
+    LOAD_REQUEST: "my-app/module/LOAD_REQUEST"
+    LOAD_SUCCESS: "my-app/module/LOAD_SUCCESS"
+    LOAD_FAIL: "my-app/module/LOAD_FAIL"
+    SAVE_REQUEST: "my-app/module/SAVE_REQUEST"
+    SAVE_SUCCESS: "my-app/module/SAVE_SUCCESS"
+    SAVE_FAIL: "my-app/module/SAVE_FAIL"
+    UPDATE_REQUEST: "my-app/module/UPDATE_REQUEST"
+    UPDATE_SUCCESS: "my-app/module/UPDATE_SUCCESS"
+    UPDATE_FAIL: "my-app/module/UPDATE_FAIL"
+    REMOVE_REQUEST: "my-app/module/REMOVE_REQUEST"
+    REMOVE_COMPLETE: "my-app/module/REMOVE_COMPLETE"
   }
 */
+
+
+
 ```

--- a/README.md
+++ b/README.md
@@ -12,25 +12,21 @@ export const types = createTypes('my-app/module/',
   async('LOAD'),
   async('SAVE'),
   async('UPDATE'),
-  async('REMOVE')
+  async('REMOVE', ['REQUEST', 'COMPLETE'])
 )
 
 /*
   types = {
     SORT: 'my-app/module/SORT',
     ADD: 'my-app/module/ADD',
-    LOAD: 'my-app/module/LOAD',
     LOAD_SUCCESS: 'my-app/module/LOAD_SUCCESS',
     LOAD_FAIL: 'my-app/module/LOAD_FAIL',
-    SAVE: 'my-app/module/SAVE',
     SAVE_SUCCESS: 'my-app/module/SAVE_SUCCESS',
     SAVE_FAIL: 'my-app/module/SAVE_FAIL',
-    UPDATE: 'my-app/module/UPDATE',
     UPDATE_SUCCESS: 'my-app/module/UPDATE_SUCCESS',
     UPDATE_FAIL: 'my-app/module/UPDATE_FAIL',
-    REMOVE: 'my-app/module/REMOVE',
-    REMOVE_SUCCESS: 'my-app/module/REMOVE_SUCCESS',
-    REMOVE_FAIL: 'my-app/module/REMOVE_FAIL'
+    REMOVE_SUCCESS: 'my-app/module/REMOVE_REQUEST',
+    REMOVE_FAIL: 'my-app/module/REMOVE_COMPLETE'
   }
 */
 ```

--- a/index.js
+++ b/index.js
@@ -5,6 +5,6 @@ export function createTypes(prefix, ...args) {
   }, {})
 }
 
-export function async(type) {
-  return [type, `${type}_SUCCESS`, `${type}_FAIL`]
+export function async(type, subTypes = ["REQUEST", "SUCCESS", "FAIL"]) {
+  return [].concat(subTypes.map(t => `${type}_${t}`));
 }


### PR DESCRIPTION
Hi,

I'm suggesting here a small modification to the async function in order to add more flexibility.

By default, the async function will NOT output the plain type anymore (ex. UPDATE), only the following "sub" types (_REQUEST, _SUCCESS, and _FAIL).

The new subTypes parameter will let precise which "sub" type to output, for example _REQUEST and _COMPLETE instead... 